### PR TITLE
Make sure Hugging Face download stats work, better discoverability

### DIFF
--- a/micro_diffusion/models/dit.py
+++ b/micro_diffusion/models/dit.py
@@ -5,6 +5,8 @@ import numpy as np
 from timm.models.vision_transformer import PatchEmbed
 from typing import List
 
+from huggingface_hub import PyTorchModelHubMixin
+
 from .utils import (CaptionProjection, CrossAttention, Mlp, SelfAttention, T2IFinalLayer,
                    TimestepEmbedder, create_norm, get_2d_sincos_pos_embed, get_mask,
                    mask_out_token, modulate, unmask_tokens)
@@ -246,7 +248,7 @@ class DiTBlock(nn.Module):
         self.mlp.custom_init(self.weight_init_std)
     
 
-class DiT(nn.Module):
+class DiT(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/SonyResearch/micro_diffusion", pipeline_tag="text-to-image", license="apache-2.0"):
     """
     Diffusion Transformer (DiT) model than support conditioning on caption embeddings for text-to-image generation.
     

--- a/push_and_load_from_hf.py
+++ b/push_and_load_from_hf.py
@@ -1,0 +1,17 @@
+from huggingface_hub import hf_hub_download
+import torch
+
+from micro_diffusion.models.dit import DiT
+
+model = DiT()
+
+# equip with weights
+filepath = hf_hub_download(repo_id="VSehwag24/MicroDiT", filename="dit_16_channel_37M_real_and_synthetic_data.pt")
+state_dict = torch.load(filepath, map_location="cpu")
+model.load_state_dict()
+
+# push to the hub
+model.push_to_hub("sony/MicroDiT-16-channel")
+
+# load from the hub
+model = DiT.from_pretrained("sony/MicroDiT-16-channel")


### PR DESCRIPTION
Hi @vsehwag-sony,

Thanks for this nice work! Great to see the models being released on the hub :)

This PR proposes to improve the 🤗 integration by leveraging the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class. This allows:
-  to automatically load the various DiT models using `from_pretrained` (and push them using `push_to_hub`)
- better discoverability using the `text-to-image` tag
- track download numbers for your models (similar to models in the Transformers library)
- use [safetensors](https://github.com/huggingface/safetensors) instead of pickle for weights serialization
- have nice model cards on a per-model basis.

Usage is as follows:

```python
from micro_diffusion.models.dit import DiT

model = DiT.from_pretrained("sony/MicroDiT-16-channel")
```

See also the `push_and_load_from_hf.py` script.

Would you be interested in this integration?

Kind regards,

Niels